### PR TITLE
update vim-plug autoload line in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,8 +1,10 @@
 " vim-plug
 
 " Load vim-plug
-if empty(glob("~/.vim/autoload/plug.vim"))
-  execute '!curl -fLo ~/.vim/autoload/plug.vim https://raw.github.com/junegunn/vim-plug/master/plug.vim'
+if empty(glob('~/.vim/autoload/plug.vim'))
+  silent !curl -fLo ~/.vim/autoload/plug.vim --create-dirs
+    \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+  autocmd VimEnter * PlugInstall --sync | source $MYVIMRC
 endif
 
 call plug#begin('~/.vim/plugged')


### PR DESCRIPTION
This is the suggested way to call vim-plug as per [the github page](https://github.com/junegunn/vim-plug/wiki/faq)

- depending on your installation,  `silent` removes extraneous command line output that you would otherwise get with `execute`

- Additional benefit is that on a clean install when you open vim,  `:PlugInstall` will run automatically 